### PR TITLE
Refactor class operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ if i == 0 {
 }
 
 -- Conditional (ternary) expressions:
-let v = cond ?? 'then' : 'else'
+let v = cond ?? 'then' :: 'else'
 
 -- Null chaining operator: return immediately (with null) if the operand itself 
 -- is null. A paw module is actually considered a function, so '?' can exist at
@@ -169,17 +169,17 @@ assert(f(4) == 3)
 |:---------|:-------------|:-----------------------------------------|:------------|
 |16        |`() [] . ?`   |Call, Subscript, Member access, Null chain|Left         |
 |15        |`! - ~`       |Not, Negate, Bitwise not                  |Right        |
-|14        |`* / // %`    |Multiply, divide, integer divide, modulus |Left         |
+|14        |`* / // %`    |Multiply, Divide, Integer divide, Modulus |Left         |
 |13        |`+ -`         |Add, Subtract                             |Left         |
 |12        |`++`          |Concatenate                               |Left         | 
-|11        |`<< >>`       |Shift left, shift right                   |Left         |
+|11        |`<< >>`       |Shift left, Shift right                   |Left         |
 |10        |`&`           |Bitwise and                               |Left         |
 |9         |`^`           |Bitwise xor                               |Left         |
-|8         |`&#124;`      |Bitwise or                                |Left         |
-|7         |`in < <= > >=`|Inclusion, relational comparisons         |Left         |
+|8         |<code>&#124;</code>|Bitwise or                           |Left         |
+|7         |`in < <= > >=`|Inclusion, Relational comparisons         |Left         |
 |6         |`== !=`       |Equality comparisons                      |Left         |
 |5         |`&&`          |And                                       |Left         |
-|4         |`&#124;&#124;`|Or                                        |Left         |
+|4         |<code>&#124;&#124;</code>|Or                             |Left         |
 |3         |`?:`          |Null coalesce                             |Left         |
 |2         |`??::`        |Conditional                               |Right        |
 |1         |`=`           |Assignment                                |Right        |
@@ -190,10 +190,7 @@ assert(f(4) == 3)
     + Better API for arrays: `paw_*_item` will throw an error if the index is out of bounds
 + Need some sort of restriction on when methods can be added to a class
 The compiler will get confused if 'self' or 'super' is used outside of a class body.
-
-+ 'for i = x,y,z' loops: should we prevent 'x,y,z' from being floats?
-For loops using floats often produce unexpected results: it's probably better to use an int loop counter and just multiply by a float constant as needed
-Also, for loops won't work with bigint right now.
++ For loops won't work with bigint right now.
 + Finish designing things first...
     + Language features:
         + `**` (pow) operator
@@ -201,7 +198,6 @@ Also, for loops won't work with bigint right now.
         + Spread operator, used in call expressions, assignments/let statements, and array literals
         + Multi-return/let/assign with Lua semantics?
         + Concurrency: fibers, coroutines?
-+ Get the fuzzer (which fuzzes source files) to work
 + Documentation
-+ Big integer math needs work (need to convert back to `paw_Int` when possible)
++ Big integer math needs work
 + Make it fast!

--- a/src/call.c
+++ b/src/call.c
@@ -104,7 +104,7 @@ void pawC_stack_overflow(paw_Env *P)
 #if PAW_STRESS > 1
 #define next_alloc(n0, dn) ((n0) + (dn))
 #else
-#define next_alloc(n0, dn) paw_max((n0) + (dn), (n0)*2)
+#define next_alloc(n0, dn) paw_max((n0) + (dn), (n0) * 2)
 #endif
 
 void pawC_stack_grow(paw_Env *P, int n)

--- a/src/debug.c
+++ b/src/debug.c
@@ -30,8 +30,6 @@ const char *paw_opcode_name(Op op)
             return "INVOKESUPER";
         case OP_CALL:
             return "CALL";
-        case OP_INHERIT:
-            return "INHERIT";
         case OP_INVOKE:
             return "INVOKE";
         case OP_JUMP:

--- a/src/gc.c
+++ b/src/gc.c
@@ -173,6 +173,7 @@ static void mark_value(paw_Env *P, Value v)
 static void traverse_proto(paw_Env *P, Proto *p)
 {
     mark_object(P, cast_object(p->name));
+    mark_object(P, cast_object(p->modname));
     for (int i = 0; i < p->nproto; ++i) {
         mark_object(P, cast_object(p->p[i]));
     }

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -12,7 +12,7 @@ typedef uint8_t OpCode;
 #define UPVALUE_LOCAL ((int)~(UINT16_MAX >> 1))
 
 #define JUMP_MAX (int)INT16_MAX
-#define decode_jump(x) ((int)(x)-JUMP_MAX)
+#define decode_jump(x) ((int)(x) - JUMP_MAX)
 #define encode_jump_over(x) ((x) + JUMP_MAX)
 #define encode_jump_back(x) (JUMP_MAX - (x))
 
@@ -49,7 +49,6 @@ OP_CLOSURE, //
 OP_INVOKE,
 OP_INVOKESUPER,
 OP_GETSUPER,
-OP_INHERIT,
 
 OP_JUMP,
 OP_JUMPFALSE,

--- a/src/value.h
+++ b/src/value.h
@@ -56,7 +56,7 @@
 #define pawV_set_object(p, o, t) (*(p) = obj2v_aux(o, t))
 #define pawV_set_null(p) ((p)->i = -1)
 #define pawV_set_bool(p, b) ((p)->u = ~((uint64_t)((b) + 1) << 47))
-#define pawV_set_int(p, i) ((p)->u = (uint64_t)VNUMBER << VINT_WIDTH | ((uint64_t)(i)&VINT_MASK))
+#define pawV_set_int(p, i) ((p)->u = (uint64_t)VNUMBER << VINT_WIDTH | ((uint64_t)(i) & VINT_MASK))
 
 #define pawV_set_float(p, F) ((p)->f = F)
 #define pawV_set_userdata(p, o) pawV_set_object(p, o, VUSERDATA)
@@ -199,6 +199,7 @@ typedef struct Proto {
     GC_HEADER;
     uint8_t is_va;
 
+    String *modname;
     String *name;
     uint8_t *source;
     int length;
@@ -208,18 +209,18 @@ typedef struct Proto {
         int pc0;
         int pc1;
         paw_Bool captured;
-    } * v;
+    } *v;
 
     struct UpValueInfo {
         String *name;
         uint16_t index;
         paw_Bool is_local;
-    } * u;
+    } *u;
 
     struct LineInfo {
         int pc;
         int line;
-    } * lines;
+    } *lines;
 
     // constants
     Value *k;

--- a/test/scripts/bubble.paw
+++ b/test/scripts/bubble.paw
@@ -1,3 +1,4 @@
+-- bubble.paw
 
 fn random(n) {
     let a = []
@@ -28,9 +29,5 @@ fn bubble(n) {
     return a
 }
 
-let n = 100000
-let time = require('time')
-let t1 = time.time()
-let a = bubble(n)
-let t2 = time.time()
-print((t2 - t1) / n * 1e9, 'ns/element')
+let n = 5000
+bubble(n)

--- a/test/test.c
+++ b/test/test.c
@@ -65,7 +65,7 @@ static void register_block(struct TestAlloc *a, size_t size0, size_t size)
 {
     if (size0) {
         unsigned *block0 = get_block(a, size0);
-        CHECK(*block0 > 0);
+        check(*block0 > 0);
         --*block0;
     }
     if (size) {
@@ -124,10 +124,10 @@ static void trash_memory(void *ptr, size_t n)
 
 static void *safe_realloc(struct TestAlloc *a, void *ptr, size_t size0, size_t size)
 {
-    CHECK(a->nbytes >= size0);
+    check(a->nbytes >= size0);
     register_block(a, size0, size);
     void *ptr2 = size ? malloc(size) : NULL;
-    CHECK(!size || ptr2); // assume success
+    check(!size || ptr2); // assume success
     if (ptr2) {
         if (ptr) {
             // resize: copy old contents
@@ -141,12 +141,12 @@ static void *safe_realloc(struct TestAlloc *a, void *ptr, size_t size0, size_t s
 #ifdef TEST_FIND_LEAK
     if (ptr) {
         struct Chunk *c = get_chunk(ptr);
-        CHECK(c->size == size0);
+        check(c->size == size0);
         c->size = 0;
     }
     if (ptr2) {
         struct Chunk *c = get_chunk(ptr2);
-        CHECK(c->size == 0);
+        check(c->size == 0);
         c->size = size;
     }
 #endif
@@ -242,7 +242,7 @@ int test_open_file(paw_Env *P, const char *name)
     FILE *file = pawO_open(pathname, "r");
     struct TestReader rd = {.file = file};
     rd.data = rd.buf;
-    CHECK(file);
+    check(file);
 
     const int status = paw_load(P, test_reader, pathname, &rd);
     pawO_close(rd.file);
@@ -258,7 +258,7 @@ int test_open_string(paw_Env *P, const char *source)
 void test_recover(paw_Env *P, paw_Bool fatal)
 {
     // Expect an error message on top of the stack.
-    CHECK(paw_get_count(P) >= 1);
+    check(paw_get_count(P) >= 1);
 
     if (fatal) {
         const char *s = paw_string(P, -1);
@@ -279,7 +279,7 @@ void test_script(const char *name, struct TestAlloc *a)
 
 paw_Int test_randint(paw_Int min, paw_Int max)
 {
-    CHECK(min <= max);
+    check(min <= max);
     return rand() % (max - min) + min;
 }
 

--- a/test/test.h
+++ b/test/test.h
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define CHECK(x)                                       \
+#define check(x)                                       \
     do {                                               \
         if (!(x)) {                                    \
             fprintf(stderr, "check failed: %s\n", #x); \

--- a/test/test_api.c
+++ b/test/test_api.c
@@ -52,10 +52,10 @@ static void finish_test(paw_Env *P)
 static int fib(paw_Env *P)
 {
     // 'fib' closure + 1 argument
-    CHECK(paw_get_count(P) == 1 + 1);
+    check(paw_get_count(P) == 1 + 1);
     const paw_Int n = paw_int(P, -1);
     paw_get_upvalue(P, 0, 0);
-    CHECK(n >= 0);
+    check(n >= 0);
 
     if (n < (int)paw_length(P, -1)) {
         // fib(n) has already been computed
@@ -93,7 +93,7 @@ static paw_Int call_fib(paw_Env *P, int n)
     paw_push_value(P, -1); // Copy closure
     paw_push_int(P, n);    // Push parameter
     const int status = paw_call(P, 1);
-    CHECK(status == PAW_OK);
+    check(status == PAW_OK);
 
     const paw_Int fibn = paw_int(P, -1);
     paw_pop(P, 1);
@@ -102,10 +102,10 @@ static paw_Int call_fib(paw_Env *P, int n)
 
 static void str_equals(paw_Env *P, int index, const char *s)
 {
-    CHECK(paw_is_string(P, index));
+    check(paw_is_string(P, index));
     const size_t n = strlen(s);
-    CHECK(n == paw_length(P, index));
-    CHECK(0 == memcmp(s, paw_string(P, index), n));
+    check(n == paw_length(P, index));
+    check(0 == memcmp(s, paw_string(P, index), n));
 }
 
 int main(void)
@@ -130,19 +130,19 @@ int main(void)
     paw_push_int(P, 123);
     paw_set_global(P, "var");
     paw_get_global(P, "var");
-    CHECK(paw_is_integer(P, -1));
-    CHECK(paw_int(P, -1) == 123);
+    check(paw_is_integer(P, -1));
+    check(paw_int(P, -1) == 123);
     paw_pop(P, 1);
 
     // Test native closures by generating Fibonacci numbers. Use an array upvalue
     // to cache intermediate results.
     paw_create_array(P, 0);
     paw_push_native(P, fib, 1);
-    CHECK(0 == call_fib(P, 0));
-    CHECK(1 == call_fib(P, 1));
-    CHECK(1 == call_fib(P, 2));
-    CHECK(55 == call_fib(P, 10));
-    CHECK(12586269025 == call_fib(P, 50));
+    check(0 == call_fib(P, 0));
+    check(1 == call_fib(P, 1));
+    check(1 == call_fib(P, 2));
+    check(55 == call_fib(P, 10));
+    check(12586269025 == call_fib(P, 50));
     paw_pop(P, 1);
 
     // Roundtrip an integer string (through bigint). Make it very long, so the
@@ -157,10 +157,10 @@ int main(void)
         paw_push_string(P, str);
         // Convert to bigint
         paw_to_integer(P, -1);
-        CHECK(paw_is_bigint(P, -1));
+        check(paw_is_bigint(P, -1));
         paw_to_string(P, -1);
-        CHECK(paw_length(P, -1) == len);
-        CHECK(0 == memcmp(str, paw_string(P, -1), len));
+        check(paw_length(P, -1) == len);
+        check(0 == memcmp(str, paw_string(P, -1), len));
         paw_pop(P, 1);
     }
 
@@ -172,7 +172,7 @@ int main(void)
         paw_arith(P, PAW_OPADD); 
         paw_push_int(P, 2);
         paw_raw_equals(P);
-        CHECK(paw_boolean(P, -1));
+        check(paw_boolean(P, -1));
         paw_pop(P, 1);
 
         // 1 << 1 <= 2
@@ -181,7 +181,7 @@ int main(void)
         paw_arith(P, PAW_OPSHL); 
         paw_push_int(P, 2);
         paw_compare(P, PAW_OPLE);
-        CHECK(paw_boolean(P, -1));
+        check(paw_boolean(P, -1));
         paw_pop(P, 1);
 
         // "ab" ++ "c" ++ 123 == "abc123"
@@ -192,7 +192,7 @@ int main(void)
         paw_arith(P, PAW_OPCONCAT);
         paw_push_string(P, "abc123");
         paw_compare(P, PAW_OPEQ);
-        CHECK(paw_boolean(P, -1));
+        check(paw_boolean(P, -1));
         paw_pop(P, 1);
     }
 

--- a/test/test_impl.c
+++ b/test/test_impl.c
@@ -19,85 +19,85 @@ static void test_primitives(void)
 
     // VNULL
     pawV_set_null(&v);
-    CHECK(pawV_get_type(v) == VNULL);
-    CHECK(pawV_is_null(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) == VNULL);
+    check(pawV_is_null(v));
+    check(!pawV_is_object(v));
 
     // VTRUE/FALSE
     pawV_set_bool(&v, PAW_TRUE);
-    CHECK(pawV_get_type(v) == VTRUE);
-    CHECK(pawV_get_bool(v));
-    CHECK(pawV_is_true(v));
-    CHECK(!pawV_is_false(v));
+    check(pawV_get_type(v) == VTRUE);
+    check(pawV_get_bool(v));
+    check(pawV_is_true(v));
+    check(!pawV_is_false(v));
     pawV_set_bool(&v, PAW_FALSE);
-    CHECK(pawV_get_type(v) == VFALSE);
-    CHECK(!pawV_get_bool(v));
-    CHECK(!pawV_is_true(v));
-    CHECK(pawV_is_false(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) == VFALSE);
+    check(!pawV_get_bool(v));
+    check(!pawV_is_true(v));
+    check(pawV_is_false(v));
+    check(!pawV_is_object(v));
 
     // pawV_is_float(v)
     pawV_set_float(&v, 0.0);
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(pawV_get_float(v) == 0.0);
-    CHECK(pawV_is_float(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(pawV_get_float(v) == 0.0);
+    check(pawV_is_float(v));
     pawV_set_float(&v, 12.3);
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(pawV_get_float(v) == 12.3);
-    CHECK(pawV_is_float(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(pawV_get_float(v) == 12.3);
+    check(pawV_is_float(v));
     pawV_set_float(&v, 12.3e123);
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(pawV_get_float(v) == 12.3e123);
-    CHECK(pawV_is_float(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(pawV_get_float(v) == 12.3e123);
+    check(pawV_is_float(v));
+    check(!pawV_is_object(v));
     pawV_set_float(&v, INFINITY);
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(!isfinite(pawV_get_float(v)));
-    CHECK(pawV_is_float(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(!isfinite(pawV_get_float(v)));
+    check(pawV_is_float(v));
+    check(!pawV_is_object(v));
     pawV_set_float(&v, -INFINITY);
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(!isfinite(pawV_get_float(v)));
-    CHECK(pawV_is_float(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(!isfinite(pawV_get_float(v)));
+    check(pawV_is_float(v));
+    check(!pawV_is_object(v));
     pawV_set_float(&v, nan(""));
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(isnan(pawV_get_float(v)));
-    CHECK(pawV_is_float(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(isnan(pawV_get_float(v)));
+    check(pawV_is_float(v));
+    check(!pawV_is_object(v));
     pawV_set_float(&v, DBL_MAX);
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(isfinite(pawV_get_float(v)));
-    CHECK(pawV_is_float(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(isfinite(pawV_get_float(v)));
+    check(pawV_is_float(v));
+    check(!pawV_is_object(v));
     pawV_set_float(&v, DBL_MIN);
-    CHECK(pawV_get_type(v) <= VNUMBER);
-    CHECK(isfinite(pawV_get_float(v)));
-    CHECK(pawV_is_float(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) <= VNUMBER);
+    check(isfinite(pawV_get_float(v)));
+    check(pawV_is_float(v));
+    check(!pawV_is_object(v));
 
     // pawV_is_int(v)
     pawV_set_int(&v, 0);
-    CHECK(pawV_get_type(v) == VNUMBER);
-    CHECK(pawV_get_int(v) == 0);
-    CHECK(pawV_is_int(v));
+    check(pawV_get_type(v) == VNUMBER);
+    check(pawV_get_int(v) == 0);
+    check(pawV_is_int(v));
     pawV_set_int(&v, 123);
-    CHECK(pawV_get_type(v) == VNUMBER);
-    CHECK(pawV_get_int(v) == 123);
-    CHECK(pawV_is_int(v));
+    check(pawV_get_type(v) == VNUMBER);
+    check(pawV_get_int(v) == 123);
+    check(pawV_is_int(v));
     pawV_set_int(&v, -123);
-    CHECK(pawV_get_type(v) == VNUMBER);
-    CHECK(pawV_get_int(v) == -123);
-    CHECK(pawV_is_int(v));
+    check(pawV_get_type(v) == VNUMBER);
+    check(pawV_get_int(v) == -123);
+    check(pawV_is_int(v));
     pawV_set_int(&v, VINT_MAX);
-    CHECK(pawV_get_type(v) == VNUMBER);
-    CHECK(pawV_get_int(v) == VINT_MAX);
-    CHECK(pawV_is_int(v));
+    check(pawV_get_type(v) == VNUMBER);
+    check(pawV_get_int(v) == VINT_MAX);
+    check(pawV_is_int(v));
     pawV_set_int(&v, VINT_MIN);
-    CHECK(pawV_get_type(v) == VNUMBER);
-    CHECK(pawV_get_int(v) == VINT_MIN);
-    CHECK(pawV_is_int(v));
-    CHECK(!pawV_is_object(v));
+    check(pawV_get_type(v) == VNUMBER);
+    check(pawV_get_int(v) == VINT_MIN);
+    check(pawV_is_int(v));
+    check(!pawV_is_object(v));
 }
 
 static void test_objects(void)
@@ -112,12 +112,12 @@ static void test_objects(void)
     Map *fake_obj = fake_ptr;
 
     pawV_set_map(&v, fake_obj);
-    CHECK(pawV_get_type(v) == VMAP);
-    CHECK(pawV_is_map(v));
-    CHECK(pawV_is_object(v));
+    check(pawV_get_type(v) == VMAP);
+    check(pawV_is_map(v));
+    check(pawV_is_object(v));
 
     Map *m = pawV_get_map(v);
-    CHECK(m == fake_ptr);
+    check(m == fake_ptr);
 }
 
 #define N 500
@@ -137,7 +137,7 @@ static void test_map(paw_Env *P)
         pawR_setitem(P);
     }
 
-    CHECK(cast_size(paw_length(P, -1)) == paw_countof(known));
+    check(cast_size(paw_length(P, -1)) == paw_countof(known));
 
     // Fill the map with nonnegative integers (may have repeats).
     paw_Int integers[N];
@@ -150,7 +150,7 @@ static void test_map(paw_Env *P)
         integers[i] = ival;
     }
 
-    CHECK(cast_size(paw_length(P, -1)) <= N + paw_countof(known));
+    check(cast_size(paw_length(P, -1)) <= N + paw_countof(known));
 
     // Add some strings (should not affect the integers).
     char strings[N][64];
@@ -163,21 +163,21 @@ static void test_map(paw_Env *P)
         pawR_setitem(P);
     }
 
-    CHECK(cast_size(paw_length(P, -1)) <= 2 * N + paw_countof(known));
+    check(cast_size(paw_length(P, -1)) <= 2 * N + paw_countof(known));
 
     // Find all items.
     for (int i = 0; i < N; ++i) {
         paw_push_value(P, -1);
         paw_push_nstring(P, strings[i], ns);
         pawR_getitem(P);
-        CHECK(paw_length(P, -1) == ns);
-        CHECK(0 == memcmp(strings[i], paw_string(P, -1), ns));
+        check(paw_length(P, -1) == ns);
+        check(0 == memcmp(strings[i], paw_string(P, -1), ns));
         paw_pop(P, 1);
 
         paw_push_value(P, -1);
         paw_push_int(P, integers[i]);
         pawR_getitem(P);
-        CHECK(paw_int(P, -1) == integers[i]);
+        check(paw_int(P, -1) == integers[i]);
         paw_pop(P, 1);
     }
 
@@ -190,7 +190,7 @@ static void test_map(paw_Env *P)
         }
     }
 
-    CHECK(cast_size(pawH_length(m)) <= N + paw_countof(known));
+    check(cast_size(pawH_length(m)) <= N + paw_countof(known));
 
     // Erase the strings.
     itr = PAW_ITER_INIT;
@@ -201,15 +201,15 @@ static void test_map(paw_Env *P)
         }
     }
 
-    CHECK(cast_size(pawH_length(m)) == paw_countof(known));
+    check(cast_size(pawH_length(m)) == paw_countof(known));
 
     // Check known items.
     for (size_t i = 0; i < paw_countof(known); ++i) {
         Value key;
         pawV_set_int(&key, known[i]);
         const Value *value = pawH_action(P, m, key, MAP_ACTION_NONE);
-        CHECK(value);
-        CHECK(pawV_get_int(*value) == known[i]);
+        check(value);
+        check(pawV_get_int(*value) == known[i]);
     }
 
     pawC_pop(P); // pop map
@@ -218,9 +218,9 @@ static void test_map(paw_Env *P)
 static void test_stack(paw_Env *P)
 {
     paw_push_nnull(P, 2);
-    CHECK(paw_get_count(P) == 2);
-    CHECK(paw_is_null(P, 0));
-    CHECK(paw_is_null(P, 1));
+    check(paw_get_count(P) == 2);
+    check(paw_is_null(P, 0));
+    check(paw_is_null(P, 1));
 }
 
 static void driver(void (*callback)(paw_Env *))

--- a/test/test_oom.c
+++ b/test/test_oom.c
@@ -39,7 +39,7 @@ static void script(const char *name)
         a.extra = nextra;
         nextra *= 2;
     } while (rc == PAW_EMEMORY);
-    CHECK(rc == PAW_OK);
+    check(rc == PAW_OK);
 }
 
 int main(void)

--- a/test/test_so.c
+++ b/test/test_so.c
@@ -26,7 +26,7 @@ int main(void)
     paw_get_global(P, "f");
     paw_push_int(P, PAW_STACK_MAX);
     status = paw_call(P, 1);
-    CHECK(status == PAW_EMEMORY);
+    check(status == PAW_EMEMORY);
     handle_error(P, status, 0);
     test_close(P, &a);
 }


### PR DESCRIPTION
Put OP_INHERIT functionality in OP_NEWCLASS, and get rid of OP_INHERIT. Lets us know how many bound attributes a class instance will need before it is created, so they can be allocated in a flexible array member later on.