### PR TITLE
Use the first parameter to hold the receiver

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -155,7 +155,7 @@ paw_Bool paw_is_instance(paw_Env *P, int index)
     return paw_type(P, index) == PAW_TINSTANCE;
 }
 
-paw_Bool paw_is_userdata(paw_Env *P, int index)
+paw_Bool paw_is_foreign(paw_Env *P, int index)
 {
     return paw_type(P, index) == PAW_TUSERDATA;
 }
@@ -192,7 +192,7 @@ int paw_type(paw_Env *P, int index)
             return PAW_TINSTANCE;
         case VNUMBER:
             return PAW_TINTEGER;
-        case VUSERDATA:
+        case VFOREIGN:
             return PAW_TUSERDATA;
         default:
             return PAW_TFLOAT;
@@ -337,8 +337,8 @@ paw_Digit *paw_bigint(paw_Env *P, int index)
 void *paw_pointer(paw_Env *P, int index)
 {
     Value *pv = access(P, index);
-    if (pawV_is_userdata(*pv)) {
-        return pawV_get_userdata(*pv)->data;
+    if (pawV_is_foreign(*pv)) {
+        return pawV_get_foreign(*pv)->data;
     }
     return pv;
 }
@@ -641,9 +641,9 @@ void paw_create_native(paw_Env *P, paw_Function f, int nup)
     paw_shift(P, nup);
 }
 
-void *paw_create_userdata(paw_Env *P, size_t size)
+void *paw_create_foreign(paw_Env *P, size_t size, int nbound)
 {
-    UserData *ud = pawV_push_userdata(P, size);
+    Foreign *ud = pawV_push_foreign(P, size, nbound);
     return ud->data;
 }
 

--- a/src/api.h
+++ b/src/api.h
@@ -30,7 +30,7 @@ static inline const char *api_typename(int type)
         case PAW_TINSTANCE:
             return "instance";
         case PAW_TUSERDATA:
-            return "userdata";
+            return "foreign";
         default:
             return "?";
     }
@@ -61,7 +61,7 @@ static inline int api_type(Value v)
             return PAW_TCLASS;
         case VINSTANCE:
             return PAW_TINSTANCE;
-        case VUSERDATA:
+        case VFOREIGN:
             return PAW_TUSERDATA;
         default:
             return PAW_TFLOAT;

--- a/src/auxlib.c
+++ b/src/auxlib.c
@@ -15,18 +15,18 @@ static void grow_buffer(paw_Env *P, Buffer *buf, int boxloc)
     paw_assert(buf->alloc <= SIZE_MAX / 2);
     const size_t alloc = buf->alloc * 2;
     if (pawL_boxed(buf)) {
-        UserData *ud = pawV_get_userdata(P->top.p[boxloc]);
+        Foreign *ud = pawV_get_foreign(P->top.p[boxloc]);
         pawM_resize(P, buf->data, buf->alloc, alloc);
         ud->data = buf->data;
         ud->size = alloc;
     } else {
-        // Add a new UserData 'box' to contain the buffer. Prevents a memory leak
+        // Add a new Foreign 'box' to contain the buffer. Prevents a memory leak
         // if an error is thrown before the buffer is freed.
-        UserData *ud = pawV_push_userdata(P, alloc);
+        Foreign *ud = pawV_push_foreign(P, alloc, 0);
         memcpy(ud->data, buf->stack, buf->size);
         buf->data = ud->data;
         Value *pbox = &P->top.p[boxloc - 1];
-        pawV_set_userdata(pbox, ud);
+        pawV_set_foreign(pbox, ud);
         paw_pop(P, 1);
     }
     buf->alloc = alloc;

--- a/src/call.h
+++ b/src/call.h
@@ -21,6 +21,8 @@ void pawC_call(paw_Env *P, Value f, int argc);
 void pawC_init(paw_Env *P);
 void pawC_uninit(paw_Env *P);
 
+StackPtr pawC_init_receiver(paw_Env *P, StackPtr base, Value func);
+
 void pawC_stack_grow(paw_Env *P, int count);
 void pawC_stack_realloc(paw_Env *P, int n);
 void pawC_stack_overflow(paw_Env *P);

--- a/src/debug.c
+++ b/src/debug.c
@@ -396,8 +396,8 @@ void paw_dump_stack(paw_Env *P)
             case VNULL:
                 puts("null");
                 break;
-            case VUSERDATA:
-                printf("userdata %p (%zu attrs)\n", pawV_get_userdata(*p)->data, pawH_length(pawV_get_userdata(*p)->attr));
+            case VFOREIGN:
+                printf("foreign %p (%zu attrs)\n", pawV_get_foreign(*p)->data, pawH_length(pawV_get_foreign(*p)->attr));
                 break;
             case VPROTO:
                 printf("proto k=%d\n", pawV_get_proto(*p)->nk);

--- a/src/env.h
+++ b/src/env.h
@@ -32,6 +32,7 @@ typedef struct CallFrame {
 } CallFrame;
 
 enum {
+    CSTR_EMPTY,
     CSTR_SELF,
     CSTR_SUPER,
     CSTR_INIT,
@@ -58,7 +59,8 @@ typedef struct paw_Env {
     StackRel top;
 
     Map *libs;
-    Map *attr[NOBJECTS];
+    Value object;
+    Foreign *builtin[NOBJECTS];
     Value meta_keys[NMETA];
     Value str_cache[NCSTR];
 

--- a/src/iolib.c
+++ b/src/iolib.c
@@ -41,14 +41,14 @@ static FILE *get_handle(paw_Env *P, int index)
 
 static FILE **create_handle(paw_Env *P)
 {
-    return paw_create_userdata(P, sizeof(FILE *));
+    return paw_create_foreign(P, sizeof(FILE *), 0);
 }
 
 static int io_open(paw_Env *P)
 {
-    pawL_check_argc(P, 2);
-    const char *path = pawL_check_string(P, 1);
-    const char *mode = pawL_check_string(P, 2);
+    pawL_check_argc(P, 3);
+    const char *path = pawL_check_string(P, 2);
+    const char *mode = pawL_check_string(P, 3);
 
     // Allocate space for the file handle
     FILE **pfile = create_handle(P);
@@ -66,16 +66,16 @@ static int io_open(paw_Env *P)
 
 static int io_close(paw_Env *P)
 {
-    pawL_check_argc(P, 1);
-    FILE *file = get_handle(P, 1);
+    pawL_check_argc(P, 2);
+    FILE *file = get_handle(P, 2);
     pawO_close(file);
     return 0;
 }
 
 static int io_flush(paw_Env *P)
 {
-    pawL_check_argc(P, 1);
-    FILE *file = get_handle(P, 1);
+    pawL_check_argc(P, 2);
+    FILE *file = get_handle(P, 2);
     if (fflush(file)) {
         pawO_system_error(P, errno);
     }
@@ -84,10 +84,10 @@ static int io_flush(paw_Env *P)
 
 static int io_read(paw_Env *P)
 {
-    pawL_check_argc(P, 2);
-    pawL_check_type(P, 2, PAW_TINTEGER);
-    FILE *file = get_handle(P, 1);
-    const paw_Int n = paw_int(P, 2);
+    pawL_check_argc(P, 3); // ..., io, file, integer
+    pawL_check_type(P, 3, PAW_TINTEGER);
+    FILE *file = get_handle(P, 2);
+    const paw_Int n = paw_int(P, 3);
 
     Buffer buf;
     pawL_init_buffer(P, &buf);
@@ -99,19 +99,19 @@ static int io_read(paw_Env *P)
 
 static int io_write(paw_Env *P)
 {
-    pawL_check_argc(P, 2);
-    const char *data = pawL_check_string(P, 2);
-    FILE *file = get_handle(P, 1);
-    pawO_write_all(P, file, data, paw_length(P, 2));
+    pawL_check_argc(P, 3); // ..., io, file, string
+    FILE *file = get_handle(P, 2);
+    const char *data = pawL_check_string(P, 3);
+    pawO_write_all(P, file, data, paw_length(P, 3));
     return 0;
 }
 
 static int io_seek(paw_Env *P)
 {
-    pawL_check_argc(P, 3);
-    const paw_Int offset = pawL_check_int(P, 2);
-    const paw_Int origin = pawL_check_int(P, 3);
-    FILE *file = get_handle(P, 1);
+    pawL_check_argc(P, 4);
+    FILE *file = get_handle(P, 2);
+    const paw_Int offset = pawL_check_int(P, 3);
+    const paw_Int origin = pawL_check_int(P, 4);
     if (p_fseek(file, offset, origin)) {
         pawO_system_error(P, errno);
     }
@@ -120,8 +120,8 @@ static int io_seek(paw_Env *P)
 
 static int io_tell(paw_Env *P)
 {
-    pawL_check_argc(P, 1);
-    FILE *file = get_handle(P, 1);
+    pawL_check_argc(P, 2);
+    FILE *file = get_handle(P, 2);
     paw_push_int(P, p_ftell(file));
     return 1;
 }

--- a/src/meta.c
+++ b/src/meta.c
@@ -72,15 +72,19 @@ const char *pawT_name(Op op)
 
 Value *pawT_get_meta_(paw_Env *P, Op op, Value obj)
 {
+    const Value key = P->meta_keys[op2meta(op)];
+    Value *bound = pawV_find_binding(P, obj, key);
+    if (bound) {
+        return bound;
+    }
     Map *meta;
     if (pawV_is_instance(obj)) {
         meta = pawV_get_instance(obj)->attr;
-    } else if (pawV_is_userdata(obj)) {
-        paw_assert(pawV_is_userdata(obj));
-        meta = pawV_get_userdata(obj)->attr;
+    } else if (pawV_is_foreign(obj)) {
+        paw_assert(pawV_is_foreign(obj));
+        meta = pawV_get_foreign(obj)->attr;
     } else {
         return NULL;
     }
-    const Value key = P->meta_keys[op2meta(op)];
     return pawH_action(P, meta, key, MAP_ACTION_NONE);
 }

--- a/src/parse.h
+++ b/src/parse.h
@@ -81,7 +81,7 @@ typedef enum FnKind {
     FN_INIT,
 } FnKind;
 
-#define FN_HAS_SELF(kind) (kind >= FN_METHOD)
+#define fn_has_self(kind) (kind >= FN_METHOD)
 
 typedef struct VarState {
     String *name;

--- a/src/paw.h
+++ b/src/paw.h
@@ -94,12 +94,9 @@ paw_Bool paw_is_map(paw_Env *P, int index);
 paw_Bool paw_is_function(paw_Env *P, int index);
 paw_Bool paw_is_class(paw_Env *P, int index);
 paw_Bool paw_is_instance(paw_Env *P, int index);
-paw_Bool paw_is_userdata(paw_Env *P, int index);
+paw_Bool paw_is_foreign(paw_Env *P, int index);
 int paw_type(paw_Env *P, int index);
 const char *paw_typename(paw_Env *P, int index);
-
-// Throw an error if the value at 'index' is not of type 'type'
-void paw_check_type(paw_Env *P, int index, int type);
 
 void paw_push_value(paw_Env *P, int index);
 void paw_push_nnull(paw_Env *P, int n);
@@ -205,7 +202,7 @@ void paw_set_itemi(paw_Env *P, int index, paw_Int i);
 void paw_call_global(paw_Env *P, const char *name, int argc);
 void paw_call_attr(paw_Env *P, int index, const char *name, int argc);
 
-void *paw_create_userdata(paw_Env *P, size_t size);
+void *paw_create_foreign(paw_Env *P, size_t size, int nbound);
 void paw_create_native(paw_Env *P, paw_Function f, int nup);
 void paw_create_class(paw_Env *P);
 void paw_create_instance(paw_Env *P, int index);

--- a/src/rt.c
+++ b/src/rt.c
@@ -98,7 +98,7 @@ static int current_line(const CallFrame *cf)
 static void add_location(paw_Env *P, Buffer *buf)
 {
     const CallFrame *cf = P->cf;
-    for (;; cf = cf->prev) {
+    for (; cf != &P->main; cf = cf->prev) {
         if (cf_is_paw(cf)) {
             const Proto *p = cf->fn->p;
             const int line = current_line(cf);
@@ -183,7 +183,9 @@ static paw_Bool meta_call(paw_Env *P, Op op, Value x, int argc)
     const Value *meta = pawT_get_meta(P, op, x);
     if (meta) {
         // Expect 'x', followed by 'argc' args, on top of the stack.
-        pawC_call(P, *meta, argc);
+        StackPtr base = vm_peek(argc);
+        base = pawC_init_receiver(P, base, *meta);
+        pawC_call(P, *meta, 1 + argc);
         return PAW_TRUE;
     }
     return PAW_FALSE;
@@ -193,8 +195,10 @@ static paw_Bool meta_unop(paw_Env *P, Op op, Value x)
 {
     const Value *meta = pawT_get_meta(P, op, x);
     if (meta) {
-        vm_pushv(x);
-        pawC_call(P, *meta, 0);
+        StackPtr sp = pawC_stkinc(P, 2);
+        sp[0] = *meta;
+        sp[1] = x;
+        pawC_call(P, *meta, 1);
         return PAW_TRUE;
     }
     return PAW_FALSE;
@@ -217,10 +221,11 @@ static paw_Bool meta_binop_aux(paw_Env *P, Op op, Value x, Value y)
         swap = PAW_TRUE;
     }
     if (meta) {
-        StackPtr sp = pawC_stkinc(P, 2);
-        sp[0] = swap ? y : x;
-        sp[1] = swap ? x : y;
-        pawC_call(P, *meta, 1);
+        StackPtr sp = pawC_stkinc(P, 3);
+        sp[0] = *meta;
+        sp[1] = swap ? y : x;
+        sp[2] = swap ? x : y;
+        pawC_call(P, *meta, 2);
         return PAW_TRUE;
     }
     return PAW_FALSE;
@@ -242,10 +247,11 @@ static inline paw_Bool meta_getter(paw_Env *P, Op op, Value obj, Value key)
 {
     const Value *meta = pawT_get_meta(P, op, obj);
     if (meta) {
-        StackPtr sp = pawC_stkinc(P, 2);
-        sp[0] = obj;
-        sp[1] = key;
-        pawC_call(P, *meta, 1);
+        StackPtr sp = pawC_stkinc(P, 3);
+        sp[0] = *meta;
+        sp[1] = obj;
+        sp[2] = key;
+        pawC_call(P, *meta, 2);
         return PAW_TRUE;
     }
     return PAW_FALSE;
@@ -255,11 +261,12 @@ static inline paw_Bool meta_setter(paw_Env *P, Op op, Value obj, Value key, Valu
 {
     const Value *meta = pawT_get_meta(P, op, obj);
     if (meta) {
-        StackPtr sp = pawC_stkinc(P, 3);
-        sp[0] = obj;
-        sp[1] = key;
-        sp[2] = val;
-        pawC_call(P, *meta, 2);
+        StackPtr sp = pawC_stkinc(P, 4);
+        sp[0] = *meta;
+        sp[1] = obj;
+        sp[2] = key;
+        sp[3] = val;
+        pawC_call(P, *meta, 3);
         vm_pop(1); // unused return value
         return PAW_TRUE;
     }
@@ -372,19 +379,17 @@ static void try_float2(paw_Env *P, Value *pv, Value *pv2, const char *what)
     }
 }
 
-static Map *attributes(paw_Env *P, const Value v, const char *what)
+static Value *find_attr(paw_Env *P, Value obj, Value name)
 {
     Map *attr = NULL;
-    if (pawV_is_instance(v)) {
-        attr = pawV_get_instance(v)->attr;
-    } else if (pawV_is_userdata(v)) {
-        attr = pawV_get_userdata(v)->attr;
-    } else if (pawV_is_object(v)) {
-        attr = P->attr[obj_index(pawV_get_type(v))];
+    if (pawV_is_instance(obj)) {
+        attr = pawV_get_instance(obj)->attr;
+    } else if (pawV_is_foreign(obj)) {
+        attr = pawV_get_foreign(obj)->attr;
     } else {
-        pawR_type_error(P, what);
+        return NULL;
     }
-    return attr;
+    return pawH_get(P, attr, name);
 }
 
 // Return true if the multiplication will overflow, false otherwise
@@ -507,22 +512,21 @@ int pawR_getattr_raw(paw_Env *P, paw_Bool has_fallback)
     const Value key = *vm_peek(0);
     paw_assert(pawV_is_string(key));
 
-    Map *attr = attributes(P, obj, "getattr");
-    const Value *pval = pawH_get(P, attr, key);
+    // Look for data attribute or non-binding function first. These attributes
+    // (added after instantiation) can shadow bound functions.
+    const Value *pval = find_attr(P, obj, key);
     if (pval) {
-        // found attribute in map
+        *vm_peek(0) = *pval;
+    } else if ((pval = pawV_find_binding(P, obj, key))) {
+        // found a binding: bind to context ('self') variable
+        Method *mtd = pawV_new_method(P, obj, *pval);
+        pawV_set_method(vm_peek(0), mtd);
     } else if (has_fallback) {
-        pval = vm_peek(2);
+        *vm_peek(0) = *vm_peek(2);
     } else {
         return -1;
     }
-    vm_pushv(*pval); // anchor
-    if (paw_is_function(P, -1)) {
-        // bind method to context ('self') variable
-        Method *mtd = pawV_new_method(P, obj, *pval);
-        pawV_set_method(&P->top.p[-1], mtd); // replace
-    }
-    vm_shift(2 + has_fallback);
+    vm_shift(1 + has_fallback);
     return 0;
 }
 
@@ -536,8 +540,8 @@ void pawR_setattr_raw(paw_Env *P)
     Map *attr = NULL;
     if (pawV_is_instance(obj)) {
         attr = pawV_get_instance(obj)->attr;
-    } else if (pawV_is_userdata(obj)) {
-        attr = pawV_get_userdata(obj)->attr;
+    } else if (pawV_is_foreign(obj)) {
+        attr = pawV_get_foreign(obj)->attr;
     } else {
         vm_pop(1); // pop 'val'
         pawR_type_error2(P, "setattr");
@@ -555,7 +559,7 @@ void pawR_setattr(paw_Env *P)
 
     if (!meta_setter(P, OP_SETATTR, obj, key, val)) {
         // Don't call pawR_setattr_raw(), since that function is allowed to set
-        // attributes on values of type 'userdata': something that should only
+        // attributes on values of type 'foreign': something that should only
         // happen from C, not paw. pawR_setattr_raw is called by C API functions
         // and the 'setattr' builtin function, while this function is called by
         // the paw runtime.
@@ -582,8 +586,8 @@ void pawR_setitem_raw(paw_Env *P)
     } else if (pawV_is_map(obj)) {
         pawH_insert(P, pawV_get_map(obj), key, val);
     } else {
-        vm_pop(1);
-        pawR_type_error(P, "setitem");
+        vm_pop(1); // pop 'val'
+        pawR_type_error2(P, "setitem");
     }
     vm_pop(3);
 }
@@ -600,30 +604,54 @@ void pawR_setitem(paw_Env *P)
     }
 }
 
-static CallFrame *invoke_from_class(paw_Env *P, Class *cls, Value name, int argc)
+static CallFrame *super_invoke(paw_Env *P, Class *super, Value name, int argc)
 {
     Value *base = vm_peek(argc);
-    const Value *method = pawH_get(P, cls->attr, name);
+    const Value *method = pawH_get(P, super->attr, name);
     if (!method) {
         pawR_attr_error(P, name);
     }
-    // The receiver instance + parameters are on top of the stack.
-    return pawC_precall(P, base, *method, argc);
+    base = pawC_init_receiver(P, base, *method);
+    return pawC_precall(P, base, *method, 1 + argc);
+}
+
+static paw_Bool bound_call(paw_Env *P, CallFrame **pcf, Value obj, StackPtr base, Value name, int argc)
+{
+    Value *bound = pawV_find_binding(P, obj, name);
+    if (bound) {
+        base = pawC_init_receiver(P, base, *bound);
+        *pcf = pawC_precall(P, base, *bound, 1 + argc);
+        return PAW_TRUE;
+    }
+    return PAW_FALSE;
 }
 
 static CallFrame *invoke(paw_Env *P, Value name, int argc)
 {
+    CallFrame *cf;
     Value *base = vm_peek(argc);
-    Map *attr = attributes(P, *base, "call");
-    const Value *method = pawH_get(P, attr, name);
-    if (method) {
-        return pawC_precall(P, base, *method, argc);
-    } else if (!pawV_is_instance(*base)) {
-        vm_pushv(*base);
-        pawR_type_error(P, ".()");
+    if (bound_call(P, &cf, *base, base, name, argc)) {
+        // found a bound function with the given 'name'
+        return cf;
     }
-    Instance *obj = pawV_get_instance(*base);
-    return invoke_from_class(P, obj->self, name, argc);
+    // attempt to call a non-bound function
+    const Value *method = find_attr(P, *base, name);
+    if (!method) {
+        pawR_attr_error(P, name);
+    }
+    *base = *method; // replace object with callable
+    return pawC_precall(P, base, *method, argc);
+}
+
+static void inherit(paw_Env *P, Class *cls, const Class *super)
+{
+    // 'copy-down' inheritance
+    pawH_extend(P, cls->attr, super->attr);
+    // Ensure that __init is not inherited. Note that 'sub' has not had any
+    // of its own attributes added to it yet, so this will not remove the
+    // actual __init attribute belonging to 'sub'.
+    const Value key = pawE_cstr(P, CSTR_INIT);
+    pawH_action(P, cls->attr, key, MAP_ACTION_REMOVE);
 }
 
 #define stop_loop(i, i2, d) (((d) < 0 && (i) <= (i2)) || \
@@ -1221,8 +1249,8 @@ void pawR_length(paw_Env *P)
         // Special case: __len may not return an integer.
         vm_shift(1);
         return;
-    } else if (pawV_is_userdata(*pv)) {
-        len = pawV_get_userdata(*pv)->size;
+    } else if (pawV_is_foreign(*pv)) {
+        len = pawV_get_foreign(*pv)->size;
     } else {
         pawR_type_error2(P, "length");
     }
@@ -1357,7 +1385,7 @@ void pawR_literal_map(paw_Env *P, int n)
         vm_shift(2 * n);
     }
 }
-
+#include "debug.h"
 void pawR_execute(paw_Env *P, CallFrame *cf)
 {
     const OpCode *pc;
@@ -1368,6 +1396,8 @@ top:
     fn = cf->fn;
 
     for (;;) {
+        //printf("%s\n",paw_opcode_name(*pc));
+        //paw_dump_stack(P);
         vm_switch(*pc++)
         {
             vm_case(POP) :
@@ -1519,12 +1549,7 @@ top:
                         pawR_error(P, PAW_ETYPE, "superclass is not of 'class' type");
                     }
                     const Class *super = pawV_get_class(parent);
-                    pawH_extend(P, cls->attr, super->attr);
-                    // Ensure that __init is not inherited. Note that 'sub' has not had any
-                    // of its own attributes added to it yet, so this will not remove the
-                    // actual __init attribute belonging to 'sub'.
-                    const Value key = pawE_cstr(P, CSTR_INIT);
-                    pawH_action(P, cls->attr, key, MAP_ACTION_REMOVE);
+                    inherit(P, cls, super);
                     // Swap the superclass and subclass. Leave the superclass on the stack.
                     // The compiler assigns it a local slot, named 'super'. It can be
                     // captured as an upvalue in methods as needed.
@@ -1573,7 +1598,7 @@ top:
                 vm_save();
 
                 Class *super = pawV_get_class(parent);
-                CallFrame *callee = invoke_from_class(P, super, name, argc);
+                CallFrame *callee = super_invoke(P, super, name, argc);
                 if (callee) {
                     cf = callee;
                     goto top;

--- a/test/scripts/basic.paw
+++ b/test/scripts/basic.paw
@@ -88,7 +88,7 @@
 
 -- __*attr, and __*item
 {
-    class C {f() {return 42}}
+    class C {f(self) {return 42}}
     fn get() {return fn() {return C()}}
     let c = C()
     c.ins = C()
@@ -261,11 +261,11 @@
     assert(test('nonnull') == 'nonnull')
 
     class Class {
-        __init() {
+        __init(self) {
             self.isnull = null
             self.nonnull = self
         }
-        __neg() {
+        __neg(self) {
             return null
         }
     }
@@ -320,7 +320,7 @@
     assert(null == test([[0]], 0, null)) -- third == null
 
     class Class {
-        __init() {
+        __init(self) {
             -- Note that 'self' is not an actual keyword: it only has special meaning
             -- in a member function. It is a local variable in this context.
             self.self = self

--- a/test/scripts/bubble.paw
+++ b/test/scripts/bubble.paw
@@ -29,5 +29,5 @@ fn bubble(n) {
     return a
 }
 
-let n = 5000
+let n = 500000
 bubble(n)

--- a/test/scripts/class.paw
+++ b/test/scripts/class.paw
@@ -1,6 +1,41 @@
 -- class.paw
 
 {
+    class A {}
+    let a = A()
+
+    -- Functions added after __init are not bound to the instance. They
+    -- can be called and assigned to variables, but they will not receive
+    -- the hidden 'self' parameter, nor will they have access to 'super'.
+    a.a = fn() {}
+    a.b = fn(a) {return a}
+    assert(a.a() == null)
+    assert(a.b(42) == 42)
+
+    let aa = a.a
+    let ab = a.b
+    assert(aa() == null)
+    assert(ab(42) == 42)
+}
+
+{
+    fn test(code) {
+        fn test() {
+            load(code)() 
+        }
+        assert(0 != try(test))
+    }
+    -- Classes are closed after creation (after closing '}' is encountered
+    -- in class the definition).
+    test('class A {}; A.a = 123')
+    test('class A {}; A.a = fn() {}')
+
+    -- Non-bound functions cannot access 'self' or 'super'.
+    test('class A {}; let a = A(); a.a = fn() {self.value = 123}; a.a()')
+    test('class A {}; let a = A(); a.a = fn() {super.value = 123}; a.a()')
+}
+
+{
     fn test(ins) {
         -- 'c' and 'd' do not exist. Attempting to access either is an error.
         assert(ins.a == 1)
@@ -13,12 +48,12 @@
     }
 
     class Class {
-        __init() {
+        __init(self) {
             self.a = 1
             self.b = null
         }
 
-        method() {
+        method(self) {
             self.b = 2
             self.c = 3
         }
@@ -39,7 +74,7 @@
             let c = [0]
 
             class Capture {
-                __init() {
+                __init(self) {
                     self.a = a
                     self.b = b
                     self.c = c
@@ -84,10 +119,10 @@
     {
         {
             class Class {
-                setter(x) {
+                setter(self, x) {
                     self.x = x
                 }
-                getter() {
+                getter(self) {
                     return self.x
                 }
             }
@@ -102,10 +137,10 @@
         {
             let x = 0
             class Class {
-                setter(y) {
+                setter(self, y) {
                     x = y
                 }
-                getter() {
+                getter(self) {
                     return x
                 }
             }
@@ -118,11 +153,11 @@
 
 {
     class Class {
-        __init() {
+        __init(self) {
             self.cls = Class
             self.num = 42
         }
-        test() {
+        test(self) {
             self.ins = self.cls()
         }
     }
@@ -135,7 +170,7 @@
 
 {
     class Class {
-        count(n) {
+        count(self, n) {
             assert(n >= 0)
             return n == 0 ?? 0 :: 1 + self.count(n - 1)
         }
@@ -153,7 +188,7 @@
     let c = Child()
 
     let n = 0
-    class Parent {method() {n = n + 1}}
+    class Parent {method(self) {n = n + 1}}
     class Child: Parent {}
     let c = Child()
     let m = c.method
@@ -162,8 +197,8 @@
     assert(n == 2)
 
     let n = 0
-    class Grandparent {method() {n = -1}}
-    class Parent {method() {n = n + 1}}
+    class Grandparent {method(self) {n = -1}}
+    class Parent {method(self) {n = n + 1}}
     class Child: Parent {}
     let c = Child()
     let m = c.method
@@ -175,7 +210,7 @@
 
 {
     class Parent {
-        __init() {
+        __init(self) {
             self.name = 'Parent'
         }
     }
@@ -187,7 +222,7 @@
 
 -- Inheritance from self is not possible
 {
-    class A {f() {}}
+    class A {f(self) {}}
     class A: A {} -- superclass is 'A' from the previous line
     let a = A()
     a.f()
@@ -197,12 +232,12 @@
 {
 
     class Parent {
-        __init() {
+        __init(self) {
             self.name = 'Parent'
         }
     }
     class Child: Parent {
-        __init() {
+        __init(self) {
             super.__init()            
         }
     }
@@ -212,17 +247,17 @@
 
 {
     class A {
-        method() {
+        method(self) {
             return 'A'
         }
     }
 
     class B: A {
-        method() {
+        method(self) {
             return 'B'
         }
 
-        test() {
+        test(self) {
             return super.method()
         }
     }
@@ -234,18 +269,18 @@
 
 {
     class A {
-        __init() {
+        __init(self) {
             self.v = 'A'
         }
     }
     class B: A {
-        __init() {}
+        __init(self) {}
     }
     let b = B()
     assert(null == getattr(b, 'v', null))
 
     class B: A {
-        __init(x) {
+        __init(self, x) {
             super.__init()
         }
     }
@@ -257,7 +292,7 @@
     fn test(code) {
         load(code)()
     }
-    assert(0 != try(test, 'class A: A {}')) -- 'A' does not yet exist
+    assert(0 != try(test, 'class _ABC: _ABC {}')) -- '_ABC' not declared (declared/defined at '}')
     assert(0 != try(test, 'class A: 1 {}')) -- inherit from primitive
     assert(0 != try(test, 'class A: [] {}')) -- inherit from builtin type
 

--- a/test/scripts/misc.paw
+++ b/test/scripts/misc.paw
@@ -9,7 +9,6 @@
     io.seek(file, 0, io.begin)
     assert(io.tell(file) == 0)
     let msg = io.read(file, #input)
-
     assert(msg == input)
     io.close(file)
 }

--- a/test/scripts/operator.paw
+++ b/test/scripts/operator.paw
@@ -199,45 +199,45 @@
 {
     let alt = '' -- For metamethods with no return
     class MM {
-        __init() {self.x = ''}
-        __len() {return '__len'}
-        __neg() {return '__neg'}
-        __not() {return '__not'}
-        __bnot() {return '__bnot'}
-        __add(y) {return '__add'}
-        __sub(y) {return '__sub'}
-        __mul(y) {return '__mul'}
-        __div(y) {return '__div'}
-        __idiv(y) {return '__idiv'}
-        __mod(y) {return '__mod'}
-        __pow(y) {return '__pow'}
-        __concat(y) {return '__concat'}
-        __bxor(y) {return '__bxor'}
-        __band(y) {return '__band'}
-        __bor(y) {return '__bor'}
-        __shl(y) {return '__shl'}
-        __shr(y) {return '__shr'}
-        __eq(y) {return '__eq'}
-        __lt(y) {return '__lt'}
-        __le(y) {return '__le'}
-        __contains(x) {return '__contains'}
-        __getattr(x) {return '__getattr'}
-        __setattr(x, y) {alt = '__setattr'}
-        __getitem(x) {return '__getitem'}
-        __setitem(x, y) {alt = '__setitem'}
-        __radd(x) {return '__radd'}
-        __rsub(x) {return '__rsub'}
-        __rmul(x) {return '__rmul'}
-        __rdiv(x) {return '__rdiv'}
-        __ridiv(x) {return '__ridiv'}
-        __rmod(x) {return '__rmod'}
-        __rpow(x) {return '__rpow'}
-        __rconcat(x) {return '__rconcat'}
-        __rbxor(x) {return '__rbxor'}
-        __rband(x) {return '__rband'}
-        __rbor(x) {return '__rbor'}
-        __rshl(x) {return '__rshl'}
-        __rshr(x) {return '__rshr'}
+        __init(self) {self.x = ''}
+        __len(self) {return '__len'}
+        __neg(self) {return '__neg'}
+        __not(self) {return '__not'}
+        __bnot(self) {return '__bnot'}
+        __add(self, y) {return '__add'}
+        __sub(self, y) {return '__sub'}
+        __mul(self, y) {return '__mul'}
+        __div(self, y) {return '__div'}
+        __idiv(self, y) {return '__idiv'}
+        __mod(self, y) {return '__mod'}
+        __pow(self, y) {return '__pow'}
+        __concat(self, y) {return '__concat'}
+        __bxor(self, y) {return '__bxor'}
+        __band(self, y) {return '__band'}
+        __bor(self, y) {return '__bor'}
+        __shl(self, y) {return '__shl'}
+        __shr(self, y) {return '__shr'}
+        __eq(self, y) {return '__eq'}
+        __lt(self, y) {return '__lt'}
+        __le(self, y) {return '__le'}
+        __contains(self, x) {return '__contains'}
+        __getattr(self, x) {return '__getattr'}
+        __setattr(self, x, y) {alt = '__setattr'}
+        __getitem(self, x) {return '__getitem'}
+        __setitem(self, x, y) {alt = '__setitem'}
+        __radd(self, x) {return '__radd'}
+        __rsub(self, x) {return '__rsub'}
+        __rmul(self, x) {return '__rmul'}
+        __rdiv(self, x) {return '__rdiv'}
+        __ridiv(self, x) {return '__ridiv'}
+        __rmod(self, x) {return '__rmod'}
+        __rpow(self, x) {return '__rpow'}
+        __rconcat(self, x) {return '__rconcat'}
+        __rbxor(self, x) {return '__rbxor'}
+        __rband(self, x) {return '__rband'}
+        __rbor(self, x) {return '__rbor'}
+        __rshl(self, x) {return '__rshl'}
+        __rshr(self, x) {return '__rshr'}
     }
 
     -- Precedence helper
@@ -316,7 +316,7 @@
         }
     }
     class Meta {
-        __len() {
+        __len(self) {
             test(100)
             return 0
         }
@@ -329,7 +329,7 @@
 
 {
     class Set {
-        __init(set) {
+        __init(self, set) {
             let s = {}
             for v in set {
                 s[v] = null
@@ -337,22 +337,22 @@
             self.set = s
         }
 
-        __add(y) {
+        __add(self, y) {
             let s = self.set.clone()
             s[y] = null
             return Set(s)
         }
-        __radd(x) {
+        __radd(self, x) {
             return self.__add(x)
         }
 
-        __sub(y) {
+        __sub(self, y) {
             let s = self.set.clone()
             s.erase(y)
             return Set(s)
         }
 
-        __contains(v) {
+        __contains(self, v) {
             return v in self.set
         }
     }
@@ -382,39 +382,39 @@
 {
     -- Simulates an integer
     class Int {
-        __init(v) {self.v = v}
-        __neg() {return Int(-self.v)}
-        __not() {return Int(~self.v)}
-        __bnot() {return Int(~self.v)}
-        __add(y) {return Int(self.v + y.v)}
-        __sub(y) {return Int(self.v - y.v)}
-        __mul(y) {return Int(self.v * y.v)}
-        __div(y) {return Int(self.v / y.v)}
-        __idiv(y) {return Int(self.v // y.v)}
-        __mod(y) {return Int(self.v % y.v)}
---        __pow(y) {return Int(self.v**y.v)}
-        __concat(y) {return Int(self.v ++ y.v)}
-        __bxor(y) {return Int(self.v ^ y.v)}
-        __band(y) {return Int(self.v & y.v)}
-        __bor(y) {return Int(self.v | y.v)}
-        __shl(y) {return Int(self.v << y.v)}
-        __shr(y) {return Int(self.v >> y.v)}
-        __eq(y) {return self.v == y.v}
-        __lt(y) {return self.v < y.v}
-        __le(y) {return self.v <= y.v}
-        __radd(x) {return Int(x.v + self.v)}
-        __rsub(x) {return Int(x.v - self.v)}
-        __rmul(x) {return Int(x.v * self.v)}
-        __rdiv(x) {return Int(x.v / self.v)}
-        __ridiv(x) {return Int(x.v // self.v)}
-        __rmod(x) {return Int(x.v % self.v)}
---        __rpow(x) {return Int(x.v**self.v)}
-        __rconcat(x) {return Int(x.v ++ self.v)}
-        __rbxor(x) {return Int(x.v ^ self.v)}
-        __rband(x) {return Int(x.v & self.v)}
-        __rbor(x) {return Int(x.v | self.v)}
-        __rshl(x) {return Int(x.v << self.v)}
-        __rshr(x) {return Int(x.v >> self.v)}
+        __init(self, v) {self.v = v}
+        __neg(self) {return Int(-self.v)}
+        __not(self) {return Int(~self.v)}
+        __bnot(self) {return Int(~self.v)}
+        __add(self, y) {return Int(self.v + y.v)}
+        __sub(self, y) {return Int(self.v - y.v)}
+        __mul(self, y) {return Int(self.v * y.v)}
+        __div(self, y) {return Int(self.v / y.v)}
+        __idiv(self, y) {return Int(self.v // y.v)}
+        __mod(self, y) {return Int(self.v % y.v)}
+--        __pow(self, y) {return Int(self.v**y.v)}
+        __concat(self, y) {return Int(self.v ++ y.v)}
+        __bxor(self, y) {return Int(self.v ^ y.v)}
+        __band(self, y) {return Int(self.v & y.v)}
+        __bor(self, y) {return Int(self.v | y.v)}
+        __shl(self, y) {return Int(self.v << y.v)}
+        __shr(self, y) {return Int(self.v >> y.v)}
+        __eq(self, y) {return self.v == y.v}
+        __lt(self, y) {return self.v < y.v}
+        __le(self, y) {return self.v <= y.v}
+        __radd(self, x) {return Int(x.v + self.v)}
+        __rsub(self, x) {return Int(x.v - self.v)}
+        __rmul(self, x) {return Int(x.v * self.v)}
+        __rdiv(self, x) {return Int(x.v / self.v)}
+        __ridiv(self, x) {return Int(x.v // self.v)}
+        __rmod(self, x) {return Int(x.v % self.v)}
+--        __rpow(self, x) {return Int(x.v**self.v)}
+        __rconcat(self, x) {return Int(x.v ++ self.v)}
+        __rbxor(self, x) {return Int(x.v ^ self.v)}
+        __rband(self, x) {return Int(x.v & self.v)}
+        __rbor(self, x) {return Int(x.v | self.v)}
+        __rshl(self, x) {return Int(x.v << self.v)}
+        __rshr(self, x) {return Int(x.v >> self.v)}
     }
     fn check(lhs, rhs) {
         assert(lhs.v == rhs)
@@ -428,41 +428,41 @@
 }
 
 {
-    class MM {__call() {return 0}}
+    class MM {__call(self) {return 0}}
     let mm = MM()
     assert(mm() == 0)
 
-    class MM {__call(x) {return x}}
+    class MM {__call(self, x) {return x}}
     let mm = MM()
     assert(mm(1) == 1)
 
-    class MM {__call(x, y) {return y}}
+    class MM {__call(self, x, y) {return y}}
     let mm = MM()
     assert(mm(1, 2) == 2)
 
-    class MM {__call(x, y, z) {return z}}
+    class MM {__call(self, x, y, z) {return z}}
     let mm = MM()
     assert(mm(1, 2, 3) == 3)
 
-    class MM {__call(...) {return argv[-1]}}
+    class MM {__call(self, ...) {return argv[-1]}}
     let mm = MM()
     assert(mm(1) == 1)
     assert(mm(2) == 2)
     assert(mm(3) == 3)
 
-    class MM {__call(x, ...) {return x + argv[-1]}}
+    class MM {__call(self, x, ...) {return x + argv[-1]}}
     let mm = MM()
     assert(mm(1, 2) == 3)
     assert(mm(1, 2, 3) == 4)
     assert(mm(1, 2, 3, 4) == 5)
 
-    class MM {__call(x, y, ...) {return y + argv[-1]}}
+    class MM {__call(self, x, y, ...) {return y + argv[-1]}}
     let mm = MM()
     assert(mm(1, 2, 3) == 5)
     assert(mm(1, 2, 3, 4) == 6)
     assert(mm(1, 2, 3, 4, 5) == 7)
 
-    class MM {__call(x, y, z, ...) {return z + argv[-1]}}
+    class MM {__call(self, x, y, z, ...) {return z + argv[-1]}}
     let mm = MM()
     assert(mm(1, 2, 3, 4) == 7)
     assert(mm(1, 2, 3, 4, 5) == 8)
@@ -471,11 +471,11 @@
 
 {
     class Test {
-        __init(v) {
+        __init(self, v) {
             self.value = v
         }
 
-        __null() {
+        __null(self) {
             return self.value
                 ?? self 
                 :: null
@@ -500,15 +500,15 @@
 -- it can be used in for...in loops.
 {
     class Iterable {
-        __init(n) {
+        __init(self, n) {
             self.n = n
         }
         
-        __len() {
+        __len(self) {
             return self.n
         }
         
-        __getitem(index) {
+        __getitem(self, index) {
             return index
         }
     }

--- a/test/test_api.c
+++ b/test/test_api.c
@@ -90,8 +90,8 @@ static int fib(paw_Env *P)
 
 static paw_Int call_fib(paw_Env *P, int n)
 {
-    paw_push_value(P, -1); // Copy closure
-    paw_push_int(P, n);    // Push parameter
+    paw_push_value(P, -1); // copy closure
+    paw_push_int(P, n);    // push parameter
     const int status = paw_call(P, 1);
     check(status == PAW_OK);
 

--- a/test/test_rt.c
+++ b/test/test_rt.c
@@ -8,7 +8,8 @@ static void script(const char *name)
 
 int main(void)
 {
-    script("error");
+    script("misc");
+return 0;
     script("basic");
     script("operator");
     script("integer");
@@ -20,6 +21,7 @@ int main(void)
     script("map");
     script("string");
     script("class");
+    script("error");
     script("misc");
     script("mandelbrot");
 }


### PR DESCRIPTION
Receiver is now the first parameter to a bound function, rather than a hidden parameter called 'self'. Allows functions to be added to a class object after it is created. Those functions would become bound functions when '__init' is called. Unfortunately this requires a bit of stack manipulation to put the receiver before the parameters. This would also allow static methods that don't use the word 'self' to refer to the receiver: a more appropriate name, like 'cls', can be used. Still need to get 'super' feature to work. 'super' will need to be found at runtime, which is a bit of a pain.